### PR TITLE
#106: Utilizar plugin toolchains para selecionar JDK do build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,26 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-toolchains-plugin</artifactId>
+				<version>1.1</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>toolchain</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<toolchains>
+						<jdk>
+							<version>1.7</version>
+							<vendor>oracle</vendor>
+						</jdk>
+					</toolchains>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.5.1</version>
 				<configuration>


### PR DESCRIPTION
O plugin toolchains do maven permite a seleção de um JDK independente do
atualmente utilizado. Isto Facilita o gerenciamento da dependẽncia do
ambiente de build.

O uso do plugin implica na criação de um arquivo chamado
${HOME}/.m2/toolchains.xml, conforme exemplificado em:

https://maven.apache.org/guides/mini/guide-using-toolchains.html

Signed-off-by: Denis A. Altoé Falqueto <denisfalqueto@gmail.com>