### PR TITLE
Utilização de cache para melhorar performance

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.java]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.externalToolBuilders
 /.DS_Store
 /pom.xml.releaseBackup
+.idea

--- a/core/src/main/java/org/demoiselle/signer/core/ca/manager/CAManagerCache.java
+++ b/core/src/main/java/org/demoiselle/signer/core/ca/manager/CAManagerCache.java
@@ -4,29 +4,46 @@ import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-	
+
 public class CAManagerCache {
-	    private static CAManagerCache instance;
-	    private Map<String, Collection<X509Certificate>> cachedCertificates = new HashMap<>();
-		    
-	    private CAManagerCache() {
-	    }
-	
-	    public static CAManagerCache getInstance() {
-	        if (instance == null) {
-	            instance = new CAManagerCache();
-	        } 
-	        return instance;
-	    }
-	
-	    public Collection<X509Certificate> getCachedCertificatesFor(X509Certificate certificate) {
-		    String chave = certificate.getSerialNumber().toString();
-	        Collection<X509Certificate> certificates = cachedCertificates.get(chave);
-	        return certificates;
-	    }
-	
-	    public synchronized void addCertificate(X509Certificate certificate, Collection<X509Certificate> certificates) {
-	        String chave = certificate.getSerialNumber().toString();
-	        cachedCertificates.put(chave, certificates);	
-	    }
+	private static CAManagerCache instance;
+	private Map<String, Collection<X509Certificate>> cachedCertificates = new HashMap<>();
+	private Map<String, Boolean> isCAofCertificate = new HashMap<>();
+
+	private CAManagerCache() {
+	}
+
+	public static CAManagerCache getInstance() {
+		if (instance == null) {
+			instance = new CAManagerCache();
+		}
+		return instance;
+	}
+
+	Collection<X509Certificate> getCachedCertificatesFor(X509Certificate certificate) {
+		return cachedCertificates.get(getCertificateIdentificator(certificate));
+	}
+
+	synchronized void addCertificate(X509Certificate certificate, Collection<X509Certificate> certificates) {
+		cachedCertificates.put(getCertificateIdentificator(certificate), certificates);
+	}
+
+	Boolean getIsCAofCertificate(X509Certificate ca, X509Certificate certificate) {
+		String key = getCertificateIdentificator(ca) + "|" + getCertificateIdentificator(certificate);
+		return isCAofCertificate.containsKey(key) ? isCAofCertificate.get(key) : null;
+	}
+
+	synchronized void setIsCAofCertificate(X509Certificate ca, X509Certificate certificate, boolean value) {
+		String key = getCertificateIdentificator(ca) + "|" + getCertificateIdentificator(certificate);
+		isCAofCertificate.put(key, value);
+	}
+
+	public synchronized void invalidate() {
+		cachedCertificates.clear();
+		isCAofCertificate.clear();
+	}
+
+	private String getCertificateIdentificator(X509Certificate certificate) {
+		return certificate.getSubjectDN().getName() + certificate.getSerialNumber().toString();
+	}
 }

--- a/core/src/main/java/org/demoiselle/signer/core/ca/manager/CAManagerConfiguration.java
+++ b/core/src/main/java/org/demoiselle/signer/core/ca/manager/CAManagerConfiguration.java
@@ -39,55 +39,50 @@ package org.demoiselle.signer.core.ca.manager;
 
 public class CAManagerConfiguration {
 
-    /**
-     * System key to set cached or not cached
-     */
-    public static final String CACHED = "signer.camanager.cached";
+	/**
+	 * System key to set cached or not cached
+	 */
+	public static final String CACHED = "signer.camanager.cached";
 
-    public static CAManagerConfiguration instance = new CAManagerConfiguration();
+	public static CAManagerConfiguration instance = new CAManagerConfiguration();
+	private boolean isCached;
 
-    
-    /**
-     * to static single instance
-     *
-     * @return current instance
-     */
-    public static CAManagerConfiguration getInstance() {
-        return instance;
-    }
+	/**
+	 * Check for system variables. If there is, assign in class variables otherwise use default values.
+	 */
+	private CAManagerConfiguration() {
+		String cachedProp = (String) System.getProperties().get(CACHED);
+		if (cachedProp == null || cachedProp.isEmpty()) {
+			setCached(false);
+		} else {
+			setCached(Boolean.valueOf(cachedProp));
+		}
+	}
 
-    private boolean isCached;
+	/**
+	 * to static single instance
+	 *
+	 * @return current instance
+	 */
+	public static CAManagerConfiguration getInstance() {
+		return instance;
+	}
 
-    /**
-     * Check for system variables. If there is, assign in class variables otherwise use default values.
-     */
-    private CAManagerConfiguration() {
-        String mode_cached = (String) System.getProperties().get(CACHED);
-        if (mode_cached == null || mode_cached.isEmpty()) {
-            setCached(false);
-        } else {
-            setCached(Boolean.valueOf(mode_cached));
-        }
-    }
+	/**
+	 * Returns whether the CAManager is cached (TRUE) or not (FALSE)
+	 *
+	 * @return true (cached) or false (not cached)
+	 */
+	public boolean isCached() {
+		return isCached;
+	}
 
-    
-    /**
-     * Returns whether the CAManager is cached (TRUE) or not (FALSE) 
-     *
-     * @return true (cached) or false (not cached)
-     */
-    public boolean isCached() {
-        return isCached;
-    }
-
-    /**
-     * Determines whether the CAManager should be done cached or not
-     *
-     * @param isCached True for cached, False for not cached.
-     */
-    public void setCached(boolean isCached) {
-        this.isCached = isCached;
-    }
-
-    
+	/**
+	 * Determines whether the CAManager should be done cached or not
+	 *
+	 * @param isCached True for cached, False for not cached.
+	 */
+	public void setCached(boolean isCached) {
+		this.isCached = isCached;
+	}
 }

--- a/documentation/reference/pt-BR/core/configuracoes-ambiente.xml
+++ b/documentation/reference/pt-BR/core/configuracoes-ambiente.xml
@@ -1,96 +1,143 @@
 <?xml version='1.0' encoding="utf-8"?>
 <!DOCTYPE chapter PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
-   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" []>
+        "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" []>
 <chapter id="core-configuracoes-ambiente">
 
     <title>Configurações de Ambiente</title>
 
     <section>
         <title>Configurações de Proxy</title>
-        
+
         <para>
-            Para o caso do ambiente de rede que esteja rodando a aplicação esteja sob um Proxy é possível fazer a configuração das seguintes formas: 
-        
+            Para o caso do ambiente de rede que esteja rodando a aplicação esteja sob um Proxy é possível fazer a
+            configuração das seguintes formas:
+
             <itemizedlist>
                 <listitem>
                     <para>
-                          <emphasis>Programaticamente</emphasis>
+                        <emphasis>Programaticamente</emphasis>
                     </para>
                     <para>
-                    <programlisting role="JAVA"><![CDATA[...
+                        <programlisting role="JAVA"><![CDATA[...
                         import org.demoiselle.signer.core.util.Proxy;
                         ...
                         Proxy.setProxyEndereco("endereco_ou_ip");
-			Proxy.setProxyPorta("numero_da_porta");						
-			Proxy.setProxyUsuario("usuario"); // Caso necessário
-			Proxy.setProxySenha("senha"); // Caso necessário
-			Proxy.setProxy();
+                        Proxy.setProxyPorta("numero_da_porta");
+                        Proxy.setProxyUsuario("usuario"); // Caso necessário
+                        Proxy.setProxySenha("senha"); // Caso necessário
+                        Proxy.setProxy();
                         ...]]></programlisting>
-                        </para>
+                    </para>
                 </listitem>
                 <listitem>
                     <para>
                         <emphasis>Setando as variáveis de ambiente</emphasis>
                     </para>
                     <para>
-                    <segmentedlist> 
-                    <seglistitem>http.proxyHost</seglistitem>
-                    <seglistitem>http.proxyPort</seglistitem>
-                    <seglistitem>http.proxyUser</seglistitem>
-                    <seglistitem>http.proxyPassword</seglistitem>
-                    </segmentedlist></para>
+                        <segmentedlist>
+                            <seglistitem>http.proxyHost</seglistitem>
+                            <seglistitem>http.proxyPort</seglistitem>
+                            <seglistitem>http.proxyUser</seglistitem>
+                            <seglistitem>http.proxyPassword</seglistitem>
+                        </segmentedlist>
+                    </para>
                 </listitem>
             </itemizedlist>
-
-
-       </para>
-        
-
-
+        </para>
     </section>
     <section>
         <title>Repositório local de LPA (Lista de Políticas de Assinatura)</title>
-        
+
         <para>
-            As Listas de Política de Assinaturas, são atualizadas trimestralmente pela ICP-BRASIL, o componenente mantem estes arquivos internamente mas 
-            haverão momentos que estes arquivos estarão desatualizados. Para evitar que seja necessário atualizar a versão do componente exclusivamente para
-            este propósito, há um mencanismo de recuperação dos arquivos diretamente do site da ICP-BRASIL. 
-            E esta funcionalidade também armazena localmente o arquivo para que não seja baixado todas as vezes que o componente for acionado.
+            As Listas de Política de Assinaturas, são atualizadas trimestralmente pela ICP-BRASIL, o componenente mantem
+            estes arquivos internamente mas
+            haverão momentos que estes arquivos estarão desatualizados. Para evitar que seja necessário atualizar a
+            versão do componente exclusivamente para
+            este propósito, há um mencanismo de recuperação dos arquivos diretamente do site da ICP-BRASIL.
+            E esta funcionalidade também armazena localmente o arquivo para que não seja baixado todas as vezes que o
+            componente for acionado.
             O diretório padrão do aplicativo é:
-            </para>
-            <para>
-            	/tmp/lpas/
-            </para>
-        
-        <para>Para alterar o local padrão, existem duas forma de fazê-lo:
         </para>
-        
-            <itemizedlist>
-                <listitem>
-                    <para>
-                          <emphasis>Programaticamente</emphasis>
-                    </para>
-                    <para>
+        <para>
+            /tmp/lpas/
+        </para>
+
+        <para>Para alterar o local padrão, existem duas formas de fazê-lo:
+        </para>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <emphasis>Programaticamente</emphasis>
+                </para>
+                <para>
                     <programlisting role="JAVA"><![CDATA[...
                         ...
                         org.demoiselle.signer.core.repository.Configuration config = org.demoiselle.signer.core.repository.Configuration.getInstance();
 		        		config.setLpaPath("/tmp/meudir/");
                         ...]]></programlisting>
-                        </para>
-                </listitem>
-                <listitem>
-                    <para>
-                        <emphasis>Setando a variável de ambiente</emphasis>
-                    </para>
-                    <para>
-                    <segmentedlist> 
-                    <seglistitem>signer.repository.lpa.path</seglistitem>
-                    </segmentedlist></para>
-                </listitem>
-            </itemizedlist>    
-        
-
-
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    <emphasis>Setando a variável de ambiente</emphasis>
+                </para>
+                <para>
+                    <segmentedlist>
+                        <seglistitem>signer.repository.lpa.path</seglistitem>
+                    </segmentedlist>
+                </para>
+            </listitem>
+        </itemizedlist>
     </section>
-    
+    <section>
+        <title>Cache no CAManager</title>
+
+        <para>
+            Em ambientes onde são executadas muitas assinaturas, algumas verificações repetitivas - que não sofrem alteração
+            entre uma assinatura e outra - podem ser colocadas em cache.
+        </para>
+        <para>Atualmente as seguintes verificações são armazenadas:</para>
+        <itemizedlist>
+            <listitem>
+                <para>recuperação da cadeia de certificados associadas a um certificado</para>
+            </listitem>
+            <listitem>
+                <para>verificação de assinatura de um certificado por um outro certificado</para>
+            </listitem>
+        </itemizedlist>
+
+        <para>Por padrão esta opção vem desativada. Existem duas formas de ativá-la:</para>
+
+        <itemizedlist>
+            <listitem>
+                <para>
+                    <emphasis>Programaticamente</emphasis>
+                </para>
+                <para>
+                    <programlisting role="JAVA"><![CDATA[...
+                        ...
+                        org.demoiselle.signer.core.ca.manager.CAManagerConfiguration config = org.demoiselle.signer.core.ca.manager.CAManagerConfiguration.getInstance();
+                        config.setCached(true);
+                        ...]]></programlisting>
+                </para>
+            </listitem>
+            <listitem>
+                <para>
+                    <emphasis>Setando a variável de ambiente</emphasis>
+                </para>
+                <para>
+                    <segmentedlist>
+                        <seglistitem>signer.camanager.cached</seglistitem>
+                    </segmentedlist>
+                </para>
+            </listitem>
+        </itemizedlist>
+        <para>O cache pode ser invalidado a qualquer momento através do método invalidate:</para>
+        <programlisting role="JAVA"><![CDATA[...
+                        ...
+                        org.demoiselle.signer.core.ca.manager.CAManagerCache cacheManager = org.demoiselle.signer.core.ca.manager.CAManagerCache.getInstance();
+                        cacheManager.invalidate();
+                        ...]]></programlisting>
+    </section>
 </chapter>


### PR DESCRIPTION
Tenho um serviço web que executa a assinatura de centenas de documentos por dia. A assinatura é feita utilizando uma quantidade específica de certificados, que estão armazenados num dispositivo de segurança. Com o aumento do tráfego, começamos a ter problemas graves de performance, o que culminou na busca por pontos de melhoria (antes de provisionar novos servidores).

Após realizar um teste de carga monitorado, foi identificado que o método `isCAofCertificate`, que praticamente só chama o método `verify` da classe `X509Certificate`, era o principal responsável pelo consumo de CPU.

Conforme a documentação do método `verify`:

> "Verifies that this certificate was signed using the private key that corresponds to the specified public key."

Acredito ser seguro fazer o cache desta verificação, onde a chave é o CN e serial de ambos os certificados que são recebidos pelo método `isCAofCertificate`.

Para fazer o cache, reaproveitei a configuração (`signer.camanager.cached`) e classes já existentes. 

Efetuei, também, a limpeza de alguns trechos do código e escrevi uma documentação inicial.

### Benchmark

Descartada a primeira requisição, obtive os seguintes resultados:

| versão | comando | tempo por requisição | requisições por segundo |
| ---------|--------------|----------------------------|---------------------------------|
| *nova* | ab -n1000 -c100 'http://127.0.0.1:8080/sign/fake' | 8.585 [ms] | 116.48 [#/sec] (mean) |
| 3.3.0-SNAPSHOT | ab -n1000 -c100 'http://127.0.0.1:8080/sign/fake' | 183.138 [ms] | 5.46 [#/sec] (mean) |