### PR TITLE
Versão 3.3.2 não carrega arquivos .pfx

### DIFF
--- a/core/src/main/java/org/demoiselle/signer/core/keystore/loader/implementation/FileSystemKeyStoreLoader.java
+++ b/core/src/main/java/org/demoiselle/signer/core/keystore/loader/implementation/FileSystemKeyStoreLoader.java
@@ -103,7 +103,7 @@ public class FileSystemKeyStoreLoader implements KeyStoreLoader {
         
         KeyStore result = null;
         //String extensao = fileKeyStore.getName().substring(fileKeyStore.getName().lastIndexOf("."), fileKeyStore.getName().length());
-        if (fileKeyStore.getName().endsWith("p12") || fileKeyStore.getName().endsWith("p12")){
+        if (fileKeyStore.getName().endsWith("p12") || fileKeyStore.getName().endsWith("pfx")){
         	try {
                 result = this.getKeyStoreWithType(pinNumber, FILE_TYPE_PKCS12);
             } catch (Throwable throwable) {


### PR DESCRIPTION
Com as mudanças ocorridas para verificar senha incorreta ao carregar a keyStore de um arquivo, os arquivos .pfx não estão mais funcionando com o componente. Com essa alteração os arquivos voltam a funcionar como antes.