### PR TITLE
demoiselle#293

### DIFF
--- a/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESChecker.java
+++ b/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESChecker.java
@@ -483,6 +483,16 @@ public class CAdESChecker implements PKCS7Checker {
 			return null;
 		}
 	}
+	
+	public List<SignatureInformations> checkSignatureByHashes(Map<String, byte[]> hashes, byte[] signedData) throws SignerException {
+		this.checkHash = true;
+		this.hashes.putAll(hashes);
+		if (this.check(null, signedData)) {
+			return this.getSignaturesInfo();
+		} else {
+			return null;
+		}
+	}
 
 	private void setSignaturePolicy(PolicyFactory.Policies signaturePolicy) {
 		this.setPolicyName(signaturePolicy.name());

--- a/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESChecker.java
+++ b/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESChecker.java
@@ -484,6 +484,13 @@ public class CAdESChecker implements PKCS7Checker {
 		}
 	}
 	
+	/**
+	 * Verifica a assinatura contra um mapa de hashes calculados a partir do mesmo conteúdo, mas usando algoritmos diferentes.
+	 * @param hashes Um mapa cujas chaves são os OID dos algoritimos e os valores são o resultado do cálculo do hash para o algoritmo em questão
+	 * @param signedData Um envelope PKCS#7 ou CMS
+	 * @return A lista de SignatureInformations encontradas
+	 * @throws SignerException
+	 */
 	public List<SignatureInformations> checkSignatureByHashes(Map<String, byte[]> hashes, byte[] signedData) throws SignerException {
 		this.checkHash = true;
 		this.hashes.putAll(hashes);

--- a/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESSigner.java
+++ b/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESSigner.java
@@ -921,6 +921,15 @@ public class CAdESSigner implements PKCS7Signer {
 		return result;
 	}
 	
+	/**
+	 * Recebe o conteúdo e uma assinatura prévia e prepara a tabela de atributos assináveis. Caso o conteúdo seja nulo, 
+	 * o hash do documento a ser assinado deve ser informado na propriedade this.hash. A tabela de atributos retornada
+	 * ainda precisará receber o atributo signingTime e ser reordenada antes que possa ser realizada a assinatura.
+	 * 
+	 * @param content Conteúdo que está sendo assinado, ou null
+	 * @param previewSignature Assinatura prévia do mesmo conteúdo, para copiar os certificados
+	 * @return
+	 */
 	public AttributeTable prepareSignedAttributes(byte[] content, byte[] previewSignature) {
 		Security.addProvider(new BouncyCastleProvider());
 		if (this.certificateChain == null) {
@@ -982,6 +991,12 @@ public class CAdESSigner implements PKCS7Signer {
 		return signedAttributesTable;
 	}
 
+	/**
+	 * Seleciona os algorítmos de hash e criptografia e também o tamanho mínimo da chave que será utilizada 
+	 * para realizar a assinatura.
+	 * 
+	 * @return
+	 */
 	public AlgAndLength prepareAlgAndLength() {
 		// Recupera a lista de algoritmos da politica e o tamanho minimo da
 		// chave
@@ -1039,6 +1054,9 @@ public class CAdESSigner implements PKCS7Signer {
 		return algAndLength;
 	}
 	
+	/**
+	 * Compõe a cadeia de confiança e a valida. Verifica, também, se a política está dentro do prazo de validade. 
+	 */
 	private void validateCertificatesAndPolicy() {
 		// Recupera o(s) certificado(s) de confianca para validacao
 		Collection<X509Certificate> trustedCAs = new HashSet<X509Certificate>();
@@ -1079,6 +1097,12 @@ public class CAdESSigner implements PKCS7Signer {
 		pv.validate();
 	}
 	
+	/**
+	 * Extrai a lista de certificados incluídos em um envelope PKCS#7 ou CMS
+	 * 
+	 * @param previewSignature
+	 * @return
+	 */
 	public Certificate[] extractCertificates(byte[] previewSignature) {
 		Certificate[] certStore = new Certificate[]{};
 

--- a/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESSigner.java
+++ b/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESSigner.java
@@ -793,7 +793,7 @@ public class CAdESSigner implements PKCS7Signer {
 		return cmsSignedData;
 	}
 	
-	private byte[] envelopSignature (CMSSignedData cmsSignedData, byte[] previewSignature) {
+	public byte[] envelopSignature (CMSSignedData cmsSignedData, byte[] previewSignature) {
 
 		
 		// Consulta e adiciona os atributos não assinados//


### PR DESCRIPTION
Encapsula alguns comportamentos em novos métodos para poderem ser reutilizados. Cria uma nova função de validação que aceita múltiplos hashes simultaneamente.

Os novos métodos são:

- CAdESSigner.prepareSignedAttributes(content, previousSignature)
- CAdESSigner.prepareAlgAndLength()
- CAdESSigner.validateCertificatesAndPolicy()
- CAdESSigner.extractCertificates(signature)
- CAdESChecker.checkSignatureByHashes(hashes, signedData)

Os métodos acima são públicos, mas não foram, ainda, expostos nas interfaces. Deixo isso por conta dos commiters, se acharem conveniente.

Resolve a issue #293 e possibilita a integração com o Assijus e o Siga-Doc.