### PR TITLE
Nova classe de CRLRepository online com cache

### DIFF
--- a/core/src/main/java/org/demoiselle/signer/core/repository/CRLRepositoryFactory.java
+++ b/core/src/main/java/org/demoiselle/signer/core/repository/CRLRepositoryFactory.java
@@ -37,6 +37,8 @@
 
 package org.demoiselle.signer.core.repository;
 
+import java.util.ServiceLoader;
+
 /**
  * Factory for repository list of revoked certificates.
  */
@@ -50,6 +52,13 @@ public class CRLRepositoryFactory {
 	 * @return CRLRepository
 	 */
 	public static CRLRepository factoryCRLRepository() {
+		
+		// If ServiceLoader finds a CRLRepository then return it
+		ServiceLoader<CRLRepository> loader = ServiceLoader.load(CRLRepository.class);
+		for (CRLRepository service : loader)
+			return service;
+		
+		// Or create a repository based on the configuration
 		ConfigurationRepo conf = ConfigurationRepo.getInstance();
 		if (conf.isOnline()) {
 			return new OnLineCRLRepository(conf.getProxy());

--- a/core/src/main/java/org/demoiselle/signer/core/repository/CachedOnLineCRLRepository.java
+++ b/core/src/main/java/org/demoiselle/signer/core/repository/CachedOnLineCRLRepository.java
@@ -1,0 +1,50 @@
+package org.demoiselle.signer.core.repository;
+
+import java.net.Proxy;
+import java.util.Date;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.demoiselle.signer.core.extension.ICPBR_CRL;
+import org.demoiselle.signer.core.util.MessagesBundle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Representa um repositório online que mantem um cache das CRLs consultadas
+ * recentemente.
+ */
+public class CachedOnLineCRLRepository extends OnLineCRLRepository {
+
+	private static ConcurrentHashMap<String, ICPBR_CRL> map = new ConcurrentHashMap<>();
+
+	private final Logger logger = LoggerFactory.getLogger(CachedOnLineCRLRepository.class);
+	private static MessagesBundle coreMessagesBundle = new MessagesBundle();
+
+	public CachedOnLineCRLRepository() {
+		super();
+	}
+
+	public CachedOnLineCRLRepository(Proxy proxy) {
+		super(proxy);
+	}
+
+	@Override
+	protected ICPBR_CRL getICPBR_CRL(String uRLCRL) {
+		ICPBR_CRL crl = map.get(uRLCRL);
+
+		if (crl == null) {
+			// Se não existir, fazer o download e instalar no mapa
+			logger.debug(coreMessagesBundle.getString("info.creating.crl", uRLCRL));
+		} else if (crl.getCRL().getNextUpdate().before(new Date())) {
+			// Se estiver expirado, atualiza com a CRL mais nova
+			logger.info(coreMessagesBundle.getString("info.update.crl"));
+		} else {
+			// Se existir e for válida, utilizar
+			return crl;
+		}
+		crl = super.getICPBR_CRL(uRLCRL);
+		map.put(uRLCRL, crl);
+		return crl;
+	}
+
+}

--- a/core/src/main/java/org/demoiselle/signer/core/repository/OnLineCRLRepository.java
+++ b/core/src/main/java/org/demoiselle/signer/core/repository/OnLineCRLRepository.java
@@ -110,7 +110,7 @@ public class OnLineCRLRepository implements CRLRepository {
 		return list;
 	}
 
-	private ICPBR_CRL getICPBR_CRL(String uRLCRL) {
+	protected ICPBR_CRL getICPBR_CRL(String uRLCRL) {
 		try {
 			URL url = new URL(uRLCRL);
 			URLConnection conexao = url.openConnection(proxy);

--- a/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESChecker.java
+++ b/policy-impl-cades/src/main/java/org/demoiselle/signer/policy/impl/cades/pkcs7/impl/CAdESChecker.java
@@ -131,7 +131,8 @@ public class CAdESChecker implements PKCS7Checker {
 	 */
 
 	private boolean check(byte[] content, byte[] signedData) throws SignerException {
-		Security.addProvider(new BouncyCastleProvider());
+	    if(Security.getProvider("BC") == null)
+			Security.addProvider(new BouncyCastleProvider());
 		CMSSignedData cmsSignedData = null;
 		try {
 			if (content == null) {


### PR DESCRIPTION
Também foi feita uma adaptação para permitir que a implementação de CRLRepository seja carregada através de ServiceLoader.

Por motivos de desempenho, a chamada ao método Security.addProvider(new BouncyCastleProvider()) foi colocada dentro de um IF.