### PR TITLE
Apresenta sugestão de categoria de mensagem (#333)

### DIFF
--- a/core/src/main/java/org/demoiselle/signer/core/keystore/loader/configuration/Configuration.java
+++ b/core/src/main/java/org/demoiselle/signer/core/keystore/loader/configuration/Configuration.java
@@ -179,7 +179,7 @@ public class Configuration {
 		map.put("TokenOuSmartCard_26_neoid", winRoot.concat("/system32/SerproPkcs11.dll"));
 		map.put("TokenOuSmartCard_27_dexton_32", winRoot.concat("/system32/DXSafePKCS11.dll"));
 		map.put("TokenOuSmartCard_28_dexton_64", winRoot.concat("/system32/DXSafePKCS11.dll"));
-		
+
 
 		// ------------ Linux ------------
 		map.put("TokenOuSmartCard_29_safesign_ou_gd", "/usr/lib/libaetpkss.so");
@@ -248,7 +248,7 @@ public class Configuration {
 		}
 
 		if (!successLoad) {
-			logger.error(coreMessagesBundle.getString("error.load.driver.null"));
+			logger.warn(coreMessagesBundle.getString("warn.load.driver.notfound"));
 		}
 
 		try {

--- a/core/src/main/resources/signer_core_messages.properties
+++ b/core/src/main/resources/signer_core_messages.properties
@@ -318,3 +318,4 @@ text.timestamp.serial.number        = N\u00FAmero de s\u00E9rie do carimbo do te
 
 warn.file.null            = Nome do arquivo \u00E9 requerido, ex: /etc/driver/token.so
 warn.no.chain.on.provider = N\u00E3o foi possivel montar a cadeia com o provider: {0}
+warn.load.driver.notfound = Nenhum driver encontrado


### PR DESCRIPTION
- logger.error é substituído por logger.warn na linha [251](https://github.com/demoiselle/signer/blob/4d423739fab568df90ab7281e3d82a5b7ae76541/core/src/main/java/org/demoiselle/signer/core/keystore/loader/configuration/Configuration.java#L251)
- Criada a mensagem "warn.load.driver.notfound" para indicar com precisão a semântica da situação excepcional.
