### PR TITLE
Retornando NULL quando ocorrer erro na checagem da LCR

### DIFF
--- a/core/src/main/java/org/demoiselle/signer/core/extension/ICPBrasilExtensionLoader.java
+++ b/core/src/main/java/org/demoiselle/signer/core/extension/ICPBrasilExtensionLoader.java
@@ -43,6 +43,7 @@ import org.demoiselle.signer.core.util.MessagesBundle;
 
 import java.lang.reflect.Field;
 import java.security.cert.X509Certificate;
+import java.util.Date;
 
 /**
  * Load X.509 Extension OIDs for ICP-Brasil's extensions.
@@ -164,10 +165,11 @@ public class ICPBrasilExtensionLoader implements IOIDExtensionLoader {
 							if (cert.hasCertificatePJ()) {
 								keyValue = cert.getICPBRCertificatePJ().getBirthDate();
 							} else {
+								keyValue = "";
 								if (cert.hasCertificateEquipment()) {
-									keyValue = cert.getICPBRCertificateEquipment().getBirthDate().toString();
-								} else {
-									keyValue = "";
+									Date bithDate = cert.getICPBRCertificateEquipment().getBirthDate();
+									if (bithDate != null)
+										keyValue = cert.getICPBRCertificateEquipment().getBirthDate().toString();
 								}
 							}
 						}

--- a/core/src/main/java/org/demoiselle/signer/core/repository/OnLineCRLRepository.java
+++ b/core/src/main/java/org/demoiselle/signer/core/repository/OnLineCRLRepository.java
@@ -112,6 +112,7 @@ public class OnLineCRLRepository implements CRLRepository {
 	}
 
 	protected ICPBR_CRL getICPBR_CRL(String uRLCRL) {
+		ICPBR_CRL icpbr_crl = null;
 		try {
 			URL url = new URL(uRLCRL);
 			InputStream is;
@@ -135,20 +136,26 @@ public class OnLineCRLRepository implements CRLRepository {
 			DataInputStream inStream = new DataInputStream(is);
 			ICPBR_CRL icpbr_crl = new ICPBR_CRL(inStream);
 			inStream.close();
-			return icpbr_crl;
+			
 
 		} catch (MalformedURLException e) {
 			logger.error(coreMessagesBundle.getString("error.malformedURL", uRLCRL) + e.getMessage());
-			throw new CRLRepositoryException(coreMessagesBundle.getString("error.malformedURL", uRLCRL) + e.getMessage());
+			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.malformedURL", uRLCRL) + e.getMessage());
+			icpbr_crl = null;
 		} catch (IOException e) {
 			logger.error(coreMessagesBundle.getString("error.crl.connect", uRLCRL) + e.getMessage());
-			throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.connect", uRLCRL) + e.getMessage());
+			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.connect", uRLCRL) + e.getMessage());
+			icpbr_crl = null;
 		} catch (CRLException e) {
 			logger.error(coreMessagesBundle.getString("error.crl.exception", uRLCRL) + e.getMessage());
-			throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.exception", uRLCRL) + e.getMessage());
+			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.exception", uRLCRL) + e.getMessage());
+			icpbr_crl = null;
 		} catch (CertificateException e) {
 			logger.error(coreMessagesBundle.getString("error.crl.certificate", uRLCRL) + e.getMessage());
-			throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.certificate", uRLCRL) + e.getMessage());
+			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.certificate", uRLCRL) + e.getMessage());
+			icpbr_crl = null;
 		}
+		
+		return icpbr_crl;
 	}
 }

--- a/core/src/main/java/org/demoiselle/signer/core/repository/OnLineCRLRepository.java
+++ b/core/src/main/java/org/demoiselle/signer/core/repository/OnLineCRLRepository.java
@@ -112,7 +112,6 @@ public class OnLineCRLRepository implements CRLRepository {
 	}
 
 	protected ICPBR_CRL getICPBR_CRL(String uRLCRL) {
-		ICPBR_CRL icpbr_crl = null;
 		try {
 			URL url = new URL(uRLCRL);
 			InputStream is;
@@ -136,26 +135,20 @@ public class OnLineCRLRepository implements CRLRepository {
 			DataInputStream inStream = new DataInputStream(is);
 			ICPBR_CRL icpbr_crl = new ICPBR_CRL(inStream);
 			inStream.close();
-			
+			return icpbr_crl;
 
 		} catch (MalformedURLException e) {
 			logger.error(coreMessagesBundle.getString("error.malformedURL", uRLCRL) + e.getMessage());
-			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.malformedURL", uRLCRL) + e.getMessage());
-			icpbr_crl = null;
+			throw new CRLRepositoryException(coreMessagesBundle.getString("error.malformedURL", uRLCRL) + e.getMessage());
 		} catch (IOException e) {
 			logger.error(coreMessagesBundle.getString("error.crl.connect", uRLCRL) + e.getMessage());
-			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.connect", uRLCRL) + e.getMessage());
-			icpbr_crl = null;
+			throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.connect", uRLCRL) + e.getMessage());
 		} catch (CRLException e) {
 			logger.error(coreMessagesBundle.getString("error.crl.exception", uRLCRL) + e.getMessage());
-			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.exception", uRLCRL) + e.getMessage());
-			icpbr_crl = null;
+			throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.exception", uRLCRL) + e.getMessage());
 		} catch (CertificateException e) {
 			logger.error(coreMessagesBundle.getString("error.crl.certificate", uRLCRL) + e.getMessage());
-			//throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.certificate", uRLCRL) + e.getMessage());
-			icpbr_crl = null;
+			throw new CRLRepositoryException(coreMessagesBundle.getString("error.crl.certificate", uRLCRL) + e.getMessage());
 		}
-		
-		return icpbr_crl;
 	}
 }


### PR DESCRIPTION
Alterei o método para não lançar exceção, somente registrar log e retornar NULL para que permitir o loop continuar.
Obs.: Esse é meu primeiro pull request em um projeto GirHub, espero ter contribuido e continuar contribuindo.