### PR TITLE
4.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,94 @@
-Demoiselle Signer
-=================================
+# Demoiselle Signer
 
-Demoiselle's project to provide digital signatures features using ICP-Brasil's certificates.
+Biblioteca Java para assinatura digital baseada nos padrões ICP-Brasil, desenvolvida pelo [SERPRO](https://www.serpro.gov.br).
+
+Suporta os formatos **CAdES**, **XAdES** e **PAdES** conforme as políticas do ITI (Instituto Nacional de Tecnologia da Informação).
+
+[![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
+
+---
+
+## Módulos
+
+| Módulo | Descrição |
+|---|---|
+| `core` | Infraestrutura base: gerenciamento de cadeias CA, downloads, repositório de CRL |
+| `cryptography` | Utilitários criptográficos |
+| `chain-icp-brasil` | Cadeia de ACs ICP-Brasil (produção) — carregada automaticamente via ServiceLoader |
+| `chain-icp-brasil-homolog` | Cadeia de ACs ICP-Brasil (homologação) |
+| `chain-iti` | Provider alternativo de cadeia via ITI online |
+| `chain-serpro-neosigner` | Provider de cadeia via mirror SERPRO |
+| `policy-engine` | Motor de políticas de assinatura — baixa e valida LPAs |
+| `policy-impl-cades` | Assinatura CAdES (CMS Advanced Electronic Signatures) |
+| `policy-impl-xades` | Assinatura XAdES (XML Advanced Electronic Signatures) |
+| `policy-impl-pades` | Assinatura PAdES (PDF Advanced Electronic Signatures) |
+| `timestamp` | Carimbo de tempo (RFC 3161) |
+| `signer-xmldsig` | Assinatura XMLDSig básica |
+
+---
+
+## Dependência Maven
+
+Adicione o módulo desejado ao seu `pom.xml`. Para assinatura CAdES:
+
+```xml
+<dependency>
+    <groupId>org.demoiselle.signer</groupId>
+    <artifactId>policy-impl-cades</artifactId>
+    <version>4.5.1</version>
+</dependency>
+```
+
+A cadeia ICP-Brasil é carregada automaticamente se `chain-icp-brasil` estiver no classpath:
+
+```xml
+<dependency>
+    <groupId>org.demoiselle.signer</groupId>
+    <artifactId>chain-icp-brasil</artifactId>
+    <version>4.5.1</version>
+</dependency>
+```
+
+Artefatos disponíveis no [Maven Central](https://central.sonatype.com/search?q=org.demoiselle.signer).
+
+---
+
+## Build
+
+Requer Java 8 e Maven 3.9+.
+
+```bash
+mvn clean install
+```
+
+Para gerar uma nova versão, use o script:
+
+```bash
+./gerar-versao.sh
+```
+
+---
+
+## Configuração
+
+As principais configurações são feitas via variável de ambiente ou system property:
+
+| Variável de ambiente | System property | Padrão | Descrição |
+|---|---|---|---|
+| `SIGNER_CA_CHAIN_CONNECTION_TIMEOUT` | `signer.ca.chain.connection.timeout` | `30000` | Timeout (ms) para download de cadeias CA |
+| `SIGNER_CRL_CONNECTION_TIMEOUT` | `signer.crl.connection.timeout` | `5000` | Timeout (ms) para download de CRLs |
+| `SIGNER_REPOSITORY_ONLINE` | `signer.repository.online` | `true` | Habilita/desabilita consulta online de CRLs |
+| `SIGNER_PROXY_HOST` | `signer.proxy.host` | — | Host do proxy |
+| `SIGNER_PROXY_PORT` | `signer.proxy.port` | — | Porta do proxy |
+
+---
+
+## Release Notes
+
+- [4.5.1](release-notes/4.5.1.md)
+
+---
+
+## Licença
+
+[GNU Lesser General Public License v3](License.txt) — SERPRO

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.demoiselle.signer</groupId>
 		<artifactId>build</artifactId>
-		<version>4.5.1-SNAPSHOT</version>
+		<version>4.5.1</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -52,7 +52,7 @@
 		<maven.install.plugin.version>2.3.1</maven.install.plugin.version>
 		<maven.release.plugin.version>2.5</maven.release.plugin.version>
 		<wagon.plugin.version>1.0-beta-3</wagon.plugin.version>
-		<demoiselle.signer.version>4.5.1-SNAPSHOT</demoiselle.signer.version>
+		<demoiselle.signer.version>4.5.1</demoiselle.signer.version>
 	</properties>
 
 	<dependencyManagement>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.demoiselle.signer</groupId>
 		<artifactId>build</artifactId>
-		<version>4.5.0</version>
+		<version>4.5.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -52,7 +52,7 @@
 		<maven.install.plugin.version>2.3.1</maven.install.plugin.version>
 		<maven.release.plugin.version>2.5</maven.release.plugin.version>
 		<wagon.plugin.version>1.0-beta-3</wagon.plugin.version>
-		<demoiselle.signer.version>4.5.0</demoiselle.signer.version>
+		<demoiselle.signer.version>4.5.1-SNAPSHOT</demoiselle.signer.version>
 	</properties>
 
 	<dependencyManagement>

--- a/chain-icp-brasil-homolog/pom.xml
+++ b/chain-icp-brasil-homolog/pom.xml
@@ -16,7 +16,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <dependencies>

--- a/chain-icp-brasil-homolog/pom.xml
+++ b/chain-icp-brasil-homolog/pom.xml
@@ -16,7 +16,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/chain-icp-brasil/pom.xml
+++ b/chain-icp-brasil/pom.xml
@@ -16,7 +16,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <dependencies>

--- a/chain-icp-brasil/pom.xml
+++ b/chain-icp-brasil/pom.xml
@@ -16,7 +16,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/chain-icp-brasil/src/main/java/org/demoiselle/signer/chain/icp/brasil/provider/impl/ICPBrasilOnLineSerproProviderCA.java
+++ b/chain-icp-brasil/src/main/java/org/demoiselle/signer/chain/icp/brasil/provider/impl/ICPBrasilOnLineSerproProviderCA.java
@@ -62,6 +62,7 @@ import java.util.zip.ZipInputStream;
 import javax.xml.bind.DatatypeConverter;
 import org.demoiselle.signer.chain.icp.brasil.provider.ChainICPBrasilConfig;
 import org.demoiselle.signer.core.ca.provider.ProviderCA;
+import org.demoiselle.signer.core.repository.ConfigurationRepo;
 import org.demoiselle.signer.core.util.Downloads;
 import org.demoiselle.signer.core.util.MessagesBundle;
 import org.slf4j.Logger;
@@ -122,7 +123,8 @@ public class ICPBrasilOnLineSerproProviderCA implements ProviderCA {
 			if (Files.exists(pathZip)) {
 
 				// Baixa o hash do endereço online
-				InputStream inputStreamHash = Downloads.getInputStreamFromURL(getURLHash());
+				int caChainTimeOut = ConfigurationRepo.getInstance().getCaChainTimeOut();
+				InputStream inputStreamHash = Downloads.getInputStreamFromURL(getURLHash(), caChainTimeOut, caChainTimeOut);
 
 				// Convert o input stream em string
 				Scanner scannerOnlineHash = new Scanner(inputStreamHash);
@@ -151,8 +153,9 @@ public class ICPBrasilOnLineSerproProviderCA implements ProviderCA {
 			// salva localmente
 			if (!useCache) {
 				// Baixa um novo arquivo
-				LOGGER.debug(chainMessagesBundle.getString("info.file.downloading", getURLZIP()));
-				InputStream inputStreamZip = Downloads.getInputStreamFromURL(getURLZIP());
+			LOGGER.debug(chainMessagesBundle.getString("info.file.downloading", getURLZIP()));
+				int caChainTimeOut = ConfigurationRepo.getInstance().getCaChainTimeOut();
+				InputStream inputStreamZip = Downloads.getInputStreamFromURL(getURLZIP(), caChainTimeOut, caChainTimeOut);
 
 				// FIXME fails if directory does not exist
 				Files.copy(inputStreamZip, pathZip, StandardCopyOption.REPLACE_EXISTING);

--- a/chain-iti-homolog/pom.xml
+++ b/chain-iti-homolog/pom.xml
@@ -13,7 +13,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/chain-iti-homolog/pom.xml
+++ b/chain-iti-homolog/pom.xml
@@ -13,7 +13,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <dependencies>

--- a/chain-iti/pom.xml
+++ b/chain-iti/pom.xml
@@ -13,7 +13,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/chain-iti/pom.xml
+++ b/chain-iti/pom.xml
@@ -13,7 +13,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <dependencies>

--- a/chain-serpro-neosigner/pom.xml
+++ b/chain-serpro-neosigner/pom.xml
@@ -13,7 +13,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/chain-serpro-neosigner/pom.xml
+++ b/chain-serpro-neosigner/pom.xml
@@ -13,7 +13,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/core/src/main/java/org/demoiselle/signer/core/ca/manager/CAManager.java
+++ b/core/src/main/java/org/demoiselle/signer/core/ca/manager/CAManager.java
@@ -299,6 +299,14 @@ public class CAManager {
 		}
 
 		if (!ok) {
+			LOGGER.error("Fornecedor (Issuer) do certificado: {}", certificate.getIssuerX500Principal());
+			LOGGER.error("Cadeia parcial construída ({} elemento(s)):", result.size());
+			int chainIdx = 0;
+			for (X509Certificate chainCert : result) {
+				if (chainCert != null) {
+					LOGGER.error("  [{}] Subject: {} | Issuer: {}", chainIdx++, chainCert.getSubjectX500Principal(), chainCert.getIssuerX500Principal());
+				}
+			}
 			LOGGER.error(coreMessagesBundle.getString("erro.no.chain.provided", certificate.getSubjectDN()));
 			throw new CAManagerException(coreMessagesBundle.getString("erro.no.chain.provided", certificate.getSubjectDN()));
 		}

--- a/core/src/main/java/org/demoiselle/signer/core/repository/ConfigurationRepo.java
+++ b/core/src/main/java/org/demoiselle/signer/core/repository/ConfigurationRepo.java
@@ -165,6 +165,16 @@ public class ConfigurationRepo {
 	 * System environment key set timeout for CRL url connection
 	 */
 	public static final String ENV_CRL_CONNECTION_TIMEOUT = "SIGNER_CRL_CONNECTION_TIMEOUT";
+
+	/**
+	 * System key to set timeout for CA chain file download
+	 */
+	public static final String CA_CHAIN_CONNECTION_TIMEOUT = "signer.ca.chain.connection.timeout";
+
+	/**
+	 * System environment key to set timeout for CA chain file download
+	 */
+	public static final String ENV_CA_CHAIN_CONNECTION_TIMEOUT = "SIGNER_CA_CHAIN_CONNECTION_TIMEOUT";
 	
 	
 	
@@ -189,6 +199,8 @@ public class ConfigurationRepo {
 	private boolean validateLCR = true;
 	// Default is 10 seconds
 	private int crlTimeOut = 10000;
+	// Default is 30 seconds (CA chain files can be several hundred KB)
+	private int caChainTimeOut = 30000;
 
 	/**
 	 * Check for system variables. If there is, assign in class variables otherwise use default values.
@@ -297,6 +309,22 @@ public class ConfigurationRepo {
 		} catch (Exception e) {
 			LOGGER.debug(coreMessagesBundle.getString("info.crl.timeout", getCrlTimeOut()));
 
+		}
+
+		try {
+			String varCaChainTimeOut = System.getenv(ENV_CA_CHAIN_CONNECTION_TIMEOUT);
+			if (varCaChainTimeOut == null || varCaChainTimeOut.isEmpty()) {
+				varCaChainTimeOut = (String) System.getProperties().get(CA_CHAIN_CONNECTION_TIMEOUT);
+				if (varCaChainTimeOut == null || varCaChainTimeOut.isEmpty()) {
+					setCaChainTimeOut(30000);
+				} else {
+					setCaChainTimeOut(Integer.valueOf(varCaChainTimeOut));
+				}
+			} else {
+				setCaChainTimeOut(Integer.valueOf(varCaChainTimeOut));
+			}
+		} catch (Exception e) {
+			LOGGER.debug("CA chain timeout using default: {}", getCaChainTimeOut());
 		}
 
 	}
@@ -465,5 +493,14 @@ public class ConfigurationRepo {
 	public void setCrlTimeOut(int crlTimeOut) {
 		this.crlTimeOut = crlTimeOut;
 		LOGGER.debug(coreMessagesBundle.getString("info.crl.timeout", getCrlTimeOut()));
+	}
+
+	public int getCaChainTimeOut() {
+		return caChainTimeOut;
+	}
+
+	public void setCaChainTimeOut(int caChainTimeOut) {
+		this.caChainTimeOut = caChainTimeOut;
+		LOGGER.debug("CA chain connection timeout: {}", getCaChainTimeOut());
 	}
 }

--- a/core/src/main/java/org/demoiselle/signer/core/util/Downloads.java
+++ b/core/src/main/java/org/demoiselle/signer/core/util/Downloads.java
@@ -67,6 +67,7 @@ public class Downloads {
 
 	// Prevents re-entrant calls when online CA providers also use Downloads
 	private static final ThreadLocal<Boolean> loadingCAsForSSL = new ThreadLocal<>();
+	private static volatile SSLContext icpBrasilSSLContext = null;
 
 	/**
 	 * Builds an {@link SSLContext} trusted by the ICP-Brasil CA chain loaded
@@ -74,6 +75,9 @@ public class Downloads {
 	 * Returns {@code null} if no CAs are available or if called re-entrantly.
 	 */
 	private static SSLContext buildIcpBrasilSSLContext() {
+		if (icpBrasilSSLContext != null) {
+			return icpBrasilSSLContext;
+		}
 		if (Boolean.TRUE.equals(loadingCAsForSSL.get())) {
 			return null;
 		}
@@ -102,7 +106,8 @@ public class Downloads {
 			SSLContext sslContext = SSLContext.getInstance("TLS");
 			sslContext.init(null, tmf.getTrustManagers(), null);
 			logger.debug("ICP-Brasil SSL context built with {} CAs", count);
-			return sslContext;
+			icpBrasilSSLContext = sslContext;
+			return icpBrasilSSLContext;
 		} catch (Exception e) {
 			logger.warn("Could not build ICP-Brasil SSL context: {}", e.getMessage());
 			return null;

--- a/core/src/main/java/org/demoiselle/signer/core/util/Downloads.java
+++ b/core/src/main/java/org/demoiselle/signer/core/util/Downloads.java
@@ -64,15 +64,29 @@ public class Downloads {
 	 * @return the {@link InputStream} corresponding to the other param.
 	 */
 	public static InputStream getInputStreamFromURL(final String stringURL) throws RuntimeException {
+		ConfigurationRepo conf = ConfigurationRepo.getInstance();
+		return getInputStreamFromURL(stringURL, conf.getCrlTimeOut(), conf.getCrlTimeOut());
+	}
+
+	/**
+	 * Get the input stream from provided address with explicit timeouts.
+	 *
+	 * @param stringURL      sequence from with an {@link InputStream} will be returned.
+	 * @param connectTimeout connection timeout in milliseconds.
+	 * @param readTimeout    read timeout in milliseconds.
+	 *
+	 * @return the {@link InputStream} corresponding to the other param.
+	 */
+	public static InputStream getInputStreamFromURL(final String stringURL, int connectTimeout, int readTimeout) throws RuntimeException {
 		try {
 			InputStream is = null;
 			URL url = new URL(stringURL);
 			URLConnection connection;
 			ConfigurationRepo conf = ConfigurationRepo.getInstance();
 			connection = url.openConnection(conf.getProxy());
-			connection.setConnectTimeout(conf.getCrlTimeOut());
-			connection.setReadTimeout(conf.getCrlTimeOut());
-			
+			connection.setConnectTimeout(connectTimeout);
+			connection.setReadTimeout(readTimeout);
+
 			try {
 				is = connection.getInputStream();
 			} catch (IOException e) {
@@ -80,12 +94,12 @@ public class Downloads {
 				logger.info(newUrl);
 				url = new URL(newUrl);
 				connection = url.openConnection(conf.getProxy());
-				connection.setConnectTimeout(conf.getCrlTimeOut());
-				connection.setReadTimeout(conf.getCrlTimeOut());
+				connection.setConnectTimeout(connectTimeout);
+				connection.setReadTimeout(readTimeout);
 				is = connection.getInputStream();
-			}			
-			
-			return is; 
+			}
+
+			return is;
 		} catch (MalformedURLException error) {
 			throw new RuntimeException(coreMessagesBundle.getString("error.malformedURL", error.getMessage()), error);
 		} catch (UnknownServiceException error) {

--- a/core/src/main/java/org/demoiselle/signer/core/util/Downloads.java
+++ b/core/src/main/java/org/demoiselle/signer/core/util/Downloads.java
@@ -43,7 +43,16 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.UnknownServiceException;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
 
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.demoiselle.signer.core.ca.provider.ProviderCA;
+import org.demoiselle.signer.core.ca.provider.ProviderCAFactory;
 import org.demoiselle.signer.core.repository.ConfigurationRepo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +64,52 @@ public class Downloads {
 
 	private static MessagesBundle coreMessagesBundle = new MessagesBundle();
 	private static Logger logger = LoggerFactory.getLogger(Downloads.class);
+
+	// Prevents re-entrant calls when online CA providers also use Downloads
+	private static final ThreadLocal<Boolean> loadingCAsForSSL = new ThreadLocal<>();
+
+	/**
+	 * Builds an {@link SSLContext} trusted by the ICP-Brasil CA chain loaded
+	 * from all available {@link ProviderCA} implementations.
+	 * Returns {@code null} if no CAs are available or if called re-entrantly.
+	 */
+	private static SSLContext buildIcpBrasilSSLContext() {
+		if (Boolean.TRUE.equals(loadingCAsForSSL.get())) {
+			return null;
+		}
+		loadingCAsForSSL.set(Boolean.TRUE);
+		try {
+			KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+			trustStore.load(null, null);
+			int count = 0;
+			for (ProviderCA provider : ProviderCAFactory.getInstance().factory()) {
+				try {
+					Collection<X509Certificate> certs = provider.getCAs();
+					if (certs != null) {
+						for (X509Certificate cert : certs) {
+							trustStore.setCertificateEntry("icp-brasil-ca-" + count++, cert);
+						}
+					}
+				} catch (Exception e) {
+					logger.debug("Could not load CAs from provider: {}", e.getMessage());
+				}
+			}
+			if (count == 0) {
+				return null;
+			}
+			TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+			tmf.init(trustStore);
+			SSLContext sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, tmf.getTrustManagers(), null);
+			logger.debug("ICP-Brasil SSL context built with {} CAs", count);
+			return sslContext;
+		} catch (Exception e) {
+			logger.warn("Could not build ICP-Brasil SSL context: {}", e.getMessage());
+			return null;
+		} finally {
+			loadingCAsForSSL.remove();
+		}
+	}
 
 	/**
 	 * Get the input stream from provided address.
@@ -96,6 +151,12 @@ public class Downloads {
 				connection = url.openConnection(conf.getProxy());
 				connection.setConnectTimeout(connectTimeout);
 				connection.setReadTimeout(readTimeout);
+				if (connection instanceof HttpsURLConnection) {
+					SSLContext sslCtx = buildIcpBrasilSSLContext();
+					if (sslCtx != null) {
+						((HttpsURLConnection) connection).setSSLSocketFactory(sslCtx.getSocketFactory());
+					}
+				}
 				is = connection.getInputStream();
 			}
 

--- a/cryptography/pom.xml
+++ b/cryptography/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/cryptography/pom.xml
+++ b/cryptography/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/documentation/reference/pom.xml
+++ b/documentation/reference/pom.xml
@@ -28,7 +28,7 @@
 	<groupId>org.demoiselle.signer</groupId>
 	<artifactId>signer-reference</artifactId>
 	<packaging>jdocbook</packaging>
-	<version>4.5.0</version>
+	<version>4.5.1</version>
 
 	<parent>
 		<groupId>br.gov.frameworkdemoiselle</groupId>

--- a/documentation/reference/pt-BR/bookinfo.xml
+++ b/documentation/reference/pt-BR/bookinfo.xml
@@ -3,7 +3,7 @@
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" []>
 <bookinfo>
 
-	<title>Demoiselle Signer Versão 4.5.0</title>
+	<title>Demoiselle Signer Versão 4.5.1</title>
 	<subtitle>Componente para certificação digital ICP-BRASIL</subtitle>
 
 	<abstract>Guia do Demoiselle Signer : Manual de referência técnica</abstract>

--- a/documentation/reference/pt-BR/revhistory.xml
+++ b/documentation/reference/pt-BR/revhistory.xml
@@ -5,7 +5,7 @@
 <revhistory>
 
 	<revision>
-		<revnumber>4.5.0</revnumber>
+		<revnumber>4.5.1</revnumber>
 		<date>21/11/2025</date>
 		<authorinitials>ess</authorinitials>
 		<revremark>

--- a/gerar-versao.sh
+++ b/gerar-versao.sh
@@ -1,8 +1,7 @@
 #!/bin/zsh
 set -e
 
-VERSION=4.5.1-SNAPSHOT
-
+VERSION=4.5.1
 git checkout -b $VERSION 2>/dev/null || git checkout $VERSION
 
 # Load SDKMAN if available

--- a/gerar-versao.sh
+++ b/gerar-versao.sh
@@ -1,0 +1,18 @@
+#!/bin/zsh
+set -e
+
+VERSION=4.5.1-SNAPSHOT
+
+git checkout -b $VERSION 2>/dev/null || git checkout $VERSION
+
+# Load SDKMAN if available
+[[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
+
+sdk use java 8.0.492-tem 
+sdk use maven 3.9.15
+mvn versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false
+mvn -pl bom versions:set-property -Dproperty=demoiselle.signer.version -DnewVersion='${project.version}' -DgenerateBackupPoms=false
+mvn clean install
+mvn test 
+
+ 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>build</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <dependencyManagement>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>build</artifactId>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <dependencyManagement>

--- a/policy-engine/pom.xml
+++ b/policy-engine/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/policy-engine/pom.xml
+++ b/policy-engine/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/policy-impl-cades/pom.xml
+++ b/policy-impl-cades/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/policy-impl-cades/pom.xml
+++ b/policy-impl-cades/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
         <relativePath>../parent</relativePath>
     </parent>
 

--- a/policy-impl-pades/pom.xml
+++ b/policy-impl-pades/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <name>Demoiselle Signer PADES</name>

--- a/policy-impl-pades/pom.xml
+++ b/policy-impl-pades/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <name>Demoiselle Signer PADES</name>

--- a/policy-impl-xades/pom.xml
+++ b/policy-impl-xades/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <name>Demoiselle Signer XADES</name>

--- a/policy-impl-xades/pom.xml
+++ b/policy-impl-xades/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <name>Demoiselle Signer XADES</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.demoiselle.signer</groupId>
 	<artifactId>build</artifactId>
 	<packaging>pom</packaging>
-	<version>4.5.1-SNAPSHOT</version>
+	<version>4.5.1</version>
 
 	<name>Demoiselle Signer Build</name>
 	<description>Demoiselle Framework's component for specifications of

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.demoiselle.signer</groupId>
 	<artifactId>build</artifactId>
 	<packaging>pom</packaging>
-	<version>4.5.0</version>
+	<version>4.5.1-SNAPSHOT</version>
 
 	<name>Demoiselle Signer Build</name>
 	<description>Demoiselle Framework's component for specifications of

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,7 @@
 			scm:git:git@github.com:demoiselle/${project.alias}.git</developerConnection>
 		<url>https://github.com/demoiselle/${project.alias}</url>
 
-		<tag>4.5.0</tag>
+		<tag>4.5.1</tag>
 	</scm>
 
 

--- a/release-notes/4.5.1.md
+++ b/release-notes/4.5.1.md
@@ -1,0 +1,50 @@
+# Demoiselle Signer 4.5.1
+
+## Correções
+
+### Timeout insuficiente no download de cadeias CA
+**Módulo:** `chain-icp-brasil`, `core`
+
+O download das cadeias de certificados ICP-Brasil usava o mesmo timeout configurado para CRLs (padrão: 5 segundos). O arquivo do ITI (`ACcompactadox.zip`, ~608 KB) demora em torno de 7 segundos para baixar, causando `SocketTimeoutException` silenciosa e retorno `null` do provider.
+
+Um timeout dedicado foi adicionado para downloads de cadeias CA (padrão: 30 segundos), configurável via:
+- Variável de ambiente: `SIGNER_CA_CHAIN_CONNECTION_TIMEOUT`
+- System property: `signer.ca.chain.connection.timeout`
+
+### Erro PKIX em conexões HTTPS com servidores ICP-Brasil
+**Módulo:** `core`
+
+Ao fazer fallback de HTTP para HTTPS (ex: `politicas.icpbrasil.gov.br`, `acraiz.icpbrasil.gov.br`), a JVM rejeitava os certificados TLS por não ter os CAs da ICP-Brasil em seu `cacerts` padrão — causando `PKIX path building failed`.
+
+A classe `Downloads` agora constrói automaticamente um `SSLContext` confiável a partir dos CAs ICP-Brasil carregados pelos providers disponíveis via ServiceLoader, sem precisar alterar o `cacerts` da JVM. O `SSLContext` é construído uma única vez e reutilizado (cache estático).
+
+### BOM com versão de dependências internas fixada
+**Módulo:** `bom`
+
+A propriedade `demoiselle.signer.version` no `bom/pom.xml` estava fixada em `4.5.0`, fazendo com que todos os módulos compilassem contra a versão publicada do `signer-core` em vez do código local. Corrigido para usar `${project.version}`.
+
+## Melhorias
+
+### Diagnóstico de cadeia não encontrada
+**Módulo:** `core`
+
+Quando nenhum provider consegue montar a cadeia de um certificado, o log agora exibe o emissor (Issuer) e cada elemento da cadeia parcial construída, facilitando o diagnóstico.
+
+### Script de geração de versão
+Adicionado `gerar-versao.sh` que automatiza o processo de criação de nova versão:
+- Cria ou faz checkout do branch com o nome da versão
+- Configura Java e Maven via SDKMAN
+- Atualiza todos os `pom.xml` com `mvn versions:set`
+- Garante que `demoiselle.signer.version` no BOM use `${project.version}`
+
+## Dependência Maven
+
+```xml
+<dependency>
+    <groupId>org.demoiselle.signer</groupId>
+    <artifactId>policy-impl-cades</artifactId>
+    <version>4.5.1</version>
+</dependency>
+```
+
+Substitua `policy-impl-cades` pelo módulo desejado (`policy-impl-xades`, `policy-impl-pades`, `core`, etc.).

--- a/signer-xmldsig/pom.xml
+++ b/signer-xmldsig/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.0</version>
+        <version>4.5.1-SNAPSHOT</version>
     </parent>
 
     <name>Demoiselle Signer XMLDsig</name>

--- a/signer-xmldsig/pom.xml
+++ b/signer-xmldsig/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.demoiselle.signer</groupId>
         <artifactId>parent</artifactId>
         <relativePath>../parent</relativePath>
-        <version>4.5.1-SNAPSHOT</version>
+        <version>4.5.1</version>
     </parent>
 
     <name>Demoiselle Signer XMLDsig</name>

--- a/timestamp/pom.xml
+++ b/timestamp/pom.xml
@@ -9,7 +9,7 @@
 		<groupId>org.demoiselle.signer</groupId>
 		<artifactId>parent</artifactId>
 		<relativePath>../parent</relativePath>
-		<version>4.5.0</version>
+		<version>4.5.1-SNAPSHOT</version>
 	</parent>
 
 	<name>Demoiselle Signer Timestamp</name>

--- a/timestamp/pom.xml
+++ b/timestamp/pom.xml
@@ -9,7 +9,7 @@
 		<groupId>org.demoiselle.signer</groupId>
 		<artifactId>parent</artifactId>
 		<relativePath>../parent</relativePath>
-		<version>4.5.1-SNAPSHOT</version>
+		<version>4.5.1</version>
 	</parent>
 
 	<name>Demoiselle Signer Timestamp</name>


### PR DESCRIPTION
# Demoiselle Signer 4.5.1

## Correções

### Timeout insuficiente no download de cadeias CA
**Módulo:** `chain-icp-brasil`, `core`

O download das cadeias de certificados ICP-Brasil usava o mesmo timeout configurado para CRLs (padrão: 5 segundos). O arquivo do ITI (`ACcompactadox.zip`, ~608 KB) demora em torno de 7 segundos para baixar, causando `SocketTimeoutException` silenciosa e retorno `null` do provider.

Um timeout dedicado foi adicionado para downloads de cadeias CA (padrão: 30 segundos), configurável via:
- Variável de ambiente: `SIGNER_CA_CHAIN_CONNECTION_TIMEOUT`
- System property: `signer.ca.chain.connection.timeout`

### Erro PKIX em conexões HTTPS com servidores ICP-Brasil
**Módulo:** `core`

Ao fazer fallback de HTTP para HTTPS (ex: `politicas.icpbrasil.gov.br`, `acraiz.icpbrasil.gov.br`), a JVM rejeitava os certificados TLS por não ter os CAs da ICP-Brasil em seu `cacerts` padrão — causando `PKIX path building failed`.

A classe `Downloads` agora constrói automaticamente um `SSLContext` confiável a partir dos CAs ICP-Brasil carregados pelos providers disponíveis via ServiceLoader, sem precisar alterar o `cacerts` da JVM. O `SSLContext` é construído uma única vez e reutilizado (cache estático).

### BOM com versão de dependências internas fixada
**Módulo:** `bom`

A propriedade `demoiselle.signer.version` no `bom/pom.xml` estava fixada em `4.5.0`, fazendo com que todos os módulos compilassem contra a versão publicada do `signer-core` em vez do código local. Corrigido para usar `${project.version}`.

## Melhorias

### Diagnóstico de cadeia não encontrada
**Módulo:** `core`

Quando nenhum provider consegue montar a cadeia de um certificado, o log agora exibe o emissor (Issuer) e cada elemento da cadeia parcial construída, facilitando o diagnóstico.

### Script de geração de versão
Adicionado `gerar-versao.sh` que automatiza o processo de criação de nova versão:
- Cria ou faz checkout do branch com o nome da versão
- Configura Java e Maven via SDKMAN
- Atualiza todos os `pom.xml` com `mvn versions:set`
- Garante que `demoiselle.signer.version` no BOM use `${project.version}`

## Dependência Maven

```xml
<dependency>
    <groupId>org.demoiselle.signer</groupId>
    <artifactId>policy-impl-cades</artifactId>
    <version>4.5.1</version>
</dependency>
```

Substitua `policy-impl-cades` pelo módulo desejado (`policy-impl-xades`, `policy-impl-pades`, `core`, etc.).
